### PR TITLE
Handle unsupported links properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,7 +1579,7 @@ checksum = "64804cc6a5042d4f05379909ba25b503ec04e2c082151d62122d5dcaa274b961"
 
 [[package]]
 name = "linkpedant-for-discord"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "actix-web",
  "atomic_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkpedant-for-discord"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/src/replace/mod.rs
+++ b/src/replace/mod.rs
@@ -170,12 +170,10 @@ impl MessageProcessor {
             .to_string();
         if let Some(process_err) = process_error {
             Err(process_err)
+        } else if could_modify {
+            Ok(Some(new_msg))
         } else {
-            if could_modify {
-                Ok(Some(new_msg))
-            } else {
-                Ok(None)
-            }
+            Ok(None)
         }
     }
 }


### PR DESCRIPTION
There was a bug with how unsupported links were being processed.

It would spill out warnings into the logs even if we couldn't support the links